### PR TITLE
Fix autoloader fatal error in Composer-managed projects

### DIFF
--- a/bin/cache_manager.php
+++ b/bin/cache_manager.php
@@ -13,7 +13,34 @@
  * - info: Show cache configuration
  */
 
-require_once __DIR__ . '/../vendor/autoload.php';
+// Only include autoloader if WPLite classes are not already available
+if (!class_exists('WPLite\Core\Cache')) {
+    // Try to find the appropriate autoloader
+    $possibleAutoloaders = [
+        __DIR__ . '/../vendor/autoload.php',                 // Package standalone
+        __DIR__ . '/../../../../autoload.php',               // Package installed via Composer
+        __DIR__ . '/../../../../../autoload.php',            // Different nesting level
+        getcwd() . '/vendor/autoload.php',                   // Main project autoloader
+    ];
+    
+    $autoloaderFound = false;
+    foreach ($possibleAutoloaders as $autoloader) {
+        if (file_exists($autoloader)) {
+            require_once $autoloader;
+            $autoloaderFound = true;
+            break;
+        }
+    }
+    
+    // If no autoloader found and classes still not available, show helpful error
+    if (!$autoloaderFound || !class_exists('WPLite\Core\Cache')) {
+        throw new Exception(
+            'WPLiteCore autoloader not found. Please ensure Composer autoload is properly configured. ' .
+            'Expected WPLite\Core\Cache class to be available.'
+        );
+    }
+}
+
 require_once __DIR__ . '/../setup-files/wlc_config.php';
 
 use WPLite\WPLiteCore;

--- a/cache_manager.php
+++ b/cache_manager.php
@@ -15,7 +15,34 @@
  *   info     - Show cache configuration
  */
 
-require_once 'vendor/autoload.php';
+// Only include autoloader if WPLite classes are not already available
+if (!class_exists('WPLite\Core\Cache')) {
+    // Try to find the appropriate autoloader
+    $possibleAutoloaders = [
+        __DIR__ . '/vendor/autoload.php',                    // Package standalone
+        __DIR__ . '/../../../autoload.php',                  // Package installed via Composer
+        __DIR__ . '/../../../../autoload.php',               // Different nesting level
+        getcwd() . '/vendor/autoload.php',                   // Main project autoloader
+    ];
+    
+    $autoloaderFound = false;
+    foreach ($possibleAutoloaders as $autoloader) {
+        if (file_exists($autoloader)) {
+            require_once $autoloader;
+            $autoloaderFound = true;
+            break;
+        }
+    }
+    
+    // If no autoloader found and classes still not available, show helpful error
+    if (!$autoloaderFound || !class_exists('WPLite\Core\Cache')) {
+        throw new Exception(
+            'WPLiteCore autoloader not found. Please ensure Composer autoload is properly configured. ' .
+            'Expected WPLite\Core\Cache class to be available.'
+        );
+    }
+}
+
 require_once 'setup-files/wlc_config.php';
 
 use WPLite\Core\Cache;

--- a/cached_router.php
+++ b/cached_router.php
@@ -7,7 +7,33 @@
  * These functions extend the existing router.php functionality with caching capabilities.
  */
 
-require_once __DIR__ . '/vendor/autoload.php';
+// Only include autoloader if WPLite classes are not already available
+if (!class_exists('WPLite\Core\CachedRouter')) {
+    // Try to find the appropriate autoloader
+    $possibleAutoloaders = [
+        __DIR__ . '/vendor/autoload.php',                    // Package standalone
+        __DIR__ . '/../../../autoload.php',                  // Package installed via Composer
+        __DIR__ . '/../../../../autoload.php',               // Different nesting level
+        getcwd() . '/vendor/autoload.php',                   // Main project autoloader
+    ];
+    
+    $autoloaderFound = false;
+    foreach ($possibleAutoloaders as $autoloader) {
+        if (file_exists($autoloader)) {
+            require_once $autoloader;
+            $autoloaderFound = true;
+            break;
+        }
+    }
+    
+    // If no autoloader found and classes still not available, show helpful error
+    if (!$autoloaderFound || !class_exists('WPLite\Core\CachedRouter')) {
+        throw new Exception(
+            'WPLiteCore autoloader not found. Please ensure Composer autoload is properly configured. ' .
+            'Expected WPLite\Core\CachedRouter class to be available.'
+        );
+    }
+}
 
 use WPLite\Core\CachedRouter;
 use WPLite\Core\Cache;

--- a/setup-files/routes.php
+++ b/setup-files/routes.php
@@ -8,8 +8,34 @@ if (!file_exists('wlc_config.php')) {
     include_once 'wlc_config.php';
 }
 
-// Require the autoload file for the project
-require_once __DIR__ . '/vendor/autoload.php';
+// Only include autoloader if WPLite classes are not already available
+if (!class_exists('WPLite\WPLiteCore')) {
+    // Try to find the appropriate autoloader
+    $possibleAutoloaders = [
+        __DIR__ . '/vendor/autoload.php',                    // Package standalone
+        __DIR__ . '/../../../../autoload.php',               // Package installed via Composer
+        __DIR__ . '/../../../../../autoload.php',            // Different nesting level
+        __DIR__ . '/../vendor/autoload.php',                 // One level up
+        getcwd() . '/vendor/autoload.php',                   // Main project autoloader
+    ];
+    
+    $autoloaderFound = false;
+    foreach ($possibleAutoloaders as $autoloader) {
+        if (file_exists($autoloader)) {
+            require_once $autoloader;
+            $autoloaderFound = true;
+            break;
+        }
+    }
+    
+    // If no autoloader found and classes still not available, show helpful error
+    if (!$autoloaderFound || !class_exists('WPLite\WPLiteCore')) {
+        throw new Exception(
+            'WPLiteCore autoloader not found. Please ensure Composer autoload is properly configured. ' .
+            'Expected WPLite\WPLiteCore class to be available.'
+        );
+    }
+}
 
 // Set the subfolder based on the current request URI
 // This will help to determine the base URL for the application

--- a/setup-files/routes_with_cache.php
+++ b/setup-files/routes_with_cache.php
@@ -15,8 +15,33 @@ if (!file_exists('wlc_config.php')) {
     include_once 'wlc_config.php';
 }
 
-// Require the autoload file for the project
-require_once __DIR__ . '/../vendor/autoload.php';
+// Only include autoloader if WPLite classes are not already available
+if (!class_exists('WPLite\WPLiteCore')) {
+    // Try to find the appropriate autoloader
+    $possibleAutoloaders = [
+        __DIR__ . '/../vendor/autoload.php',                 // Package standalone
+        __DIR__ . '/../../../../autoload.php',               // Package installed via Composer
+        __DIR__ . '/../../../../../autoload.php',            // Different nesting level
+        getcwd() . '/vendor/autoload.php',                   // Main project autoloader
+    ];
+    
+    $autoloaderFound = false;
+    foreach ($possibleAutoloaders as $autoloader) {
+        if (file_exists($autoloader)) {
+            require_once $autoloader;
+            $autoloaderFound = true;
+            break;
+        }
+    }
+    
+    // If no autoloader found and classes still not available, show helpful error
+    if (!$autoloaderFound || !class_exists('WPLite\WPLiteCore')) {
+        throw new Exception(
+            'WPLiteCore autoloader not found. Please ensure Composer autoload is properly configured. ' .
+            'Expected WPLite\WPLiteCore class to be available.'
+        );
+    }
+}
 
 // Include cached router functionality
 require_once __DIR__ . '/../cached_router.php';


### PR DESCRIPTION
- Replace hardcoded vendor/autoload.php with smart autoloader detection
- Add conditional loading that checks if WPLite classes are already available
- Support multiple autoloader paths for different installation scenarios
- Prevent fatal errors when including files in projects with existing autoloaders
- Apply fix to cached_router.php, cache_manager.php, and setup files

Resolves fatal error: "Failed opening required vendor/autoload.php" when WPLiteCore is used as a Composer package in existing projects.

Files modified:
- cached_router.php: Smart autoloader detection for CachedRouter class
- cache_manager.php: Conditional autoloader for Cache class
- bin/cache_manager.php: CLI version with proper autoloader detection
- setup-files/routes.php: Setup file with autoloader fix
- setup-files/routes_with_cache.php: Cached routes setup with autoloader fix

All changes tested and verified to work in both standalone and Composer-managed environments.